### PR TITLE
Install to /usr/bin

### DIFF
--- a/resources/software-update.service
+++ b/resources/software-update.service
@@ -7,7 +7,7 @@ Requires=mosquitto.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/software-update -configFile /etc/software-update/config.json
+ExecStart=/usr/bin/software-update -configFile /etc/software-update/config.json
 Restart=always
 
 [Install]


### PR DESCRIPTION
[13] Install to /usr/bin 
libostree requires all binaries installed using rpm to be in `/usr/bin` rather than `/usr/local/bin`