### PR TITLE
The help message of the storageLocation flag doesn't contain the default value

### DIFF
--- a/internal/flags.go
+++ b/internal/flags.go
@@ -54,7 +54,7 @@ type cfg struct {
 	Broker          string   `json:"broker" def:"tcp://localhost:1883" descr:"Local MQTT broker address"`
 	Username        string   `json:"username" descr:"Username for authorized local client"`
 	Password        string   `json:"password" descr:"Password for authorized local client"`
-	StorageLocation string   `json:"storageLocation" descr:"Location of the storage"`
+	StorageLocation string   `json:"storageLocation" def:"./" descr:"Location of the storage"`
 	FeatureID       string   `json:"featureId" def:"SoftwareUpdatable" descr:"Feature identifier of SoftwareUpdatable"`
 	ModuleType      string   `json:"moduleType" def:"software" descr:"Module type of SoftwareUpdatable"`
 	ArtifactType    string   `json:"artifactType" def:"archive" descr:"Defines the module artifact type: archive or plane"`

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -54,7 +54,7 @@ type cfg struct {
 	Broker          string   `json:"broker" def:"tcp://localhost:1883" descr:"Local MQTT broker address"`
 	Username        string   `json:"username" descr:"Username for authorized local client"`
 	Password        string   `json:"password" descr:"Password for authorized local client"`
-	StorageLocation string   `json:"storageLocation" def:"./" descr:"Location of the storage"`
+	StorageLocation string   `json:"storageLocation" def:"." descr:"Location of the storage"`
 	FeatureID       string   `json:"featureId" def:"SoftwareUpdatable" descr:"Feature identifier of SoftwareUpdatable"`
 	ModuleType      string   `json:"moduleType" def:"software" descr:"Module type of SoftwareUpdatable"`
 	ArtifactType    string   `json:"artifactType" def:"archive" descr:"Defines the module artifact type: archive or plane"`

--- a/internal/flags_test.go
+++ b/internal/flags_test.go
@@ -275,7 +275,7 @@ func TestInitFlagsWithConfigMixedContent(t *testing.T) {
 		FeatureID:       getDefaultFlagValue(t, flagFeatureID),
 		ArtifactType:    getDefaultFlagValue(t, flagArtifactType),
 		ModuleType:      getDefaultFlagValue(t, flagModuleType),
-		StorageLocation: "",
+		StorageLocation: "./",
 		Username:        "test",
 		Password:        "",
 	}

--- a/internal/flags_test.go
+++ b/internal/flags_test.go
@@ -275,7 +275,7 @@ func TestInitFlagsWithConfigMixedContent(t *testing.T) {
 		FeatureID:       getDefaultFlagValue(t, flagFeatureID),
 		ArtifactType:    getDefaultFlagValue(t, flagArtifactType),
 		ModuleType:      getDefaultFlagValue(t, flagModuleType),
-		StorageLocation: "./",
+		StorageLocation: getDefaultFlagValue(t, flagStorageLocation),
 		Username:        "test",
 		Password:        "",
 	}


### PR DESCRIPTION
[#5] The help message of the storageLocation flag doesn't contain the default value

 - Added default value for storageLocation of "./"
 - Modified unit test to use this value

Signed-off-by: Velitchko Valkov <Velitchko.Valkov@bosch.io>