### PR TITLE
Apply the new Eclipse Kanto project license scheme

### DIFF
--- a/cmd/software-update/main.go
+++ b/cmd/software-update/main.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package main
 

--- a/hawkbit/lib_dependency_description.go
+++ b/hawkbit/lib_dependency_description.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_handlers.go
+++ b/hawkbit/lib_handlers.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_hash.go
+++ b/hawkbit/lib_hash.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_links.go
+++ b/hawkbit/lib_links.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_logger.go
+++ b/hawkbit/lib_logger.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_operation_status.go
+++ b/hawkbit/lib_operation_status.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_operation_status_test.go
+++ b/hawkbit/lib_operation_status_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_protocol.go
+++ b/hawkbit/lib_protocol.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_software_artifact_action.go
+++ b/hawkbit/lib_software_artifact_action.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_software_module_action.go
+++ b/hawkbit/lib_software_module_action.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_software_module_id.go
+++ b/hawkbit/lib_software_module_id.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_software_remove_action.go
+++ b/hawkbit/lib_software_remove_action.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_software_update_action.go
+++ b/hawkbit/lib_software_update_action.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/lib_status.go
+++ b/hawkbit/lib_status.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/software_updatable.go
+++ b/hawkbit/software_updatable.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/software_updatable_config.go
+++ b/hawkbit/software_updatable_config.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/software_updatable_config_test.go
+++ b/hawkbit/software_updatable_config_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/software_updatable_errors.go
+++ b/hawkbit/software_updatable_errors.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/software_updatable_internal.go
+++ b/hawkbit/software_updatable_internal.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/software_updatable_status.go
+++ b/hawkbit/software_updatable_status.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/hawkbit/software_updatable_test.go
+++ b/hawkbit/software_updatable_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package hawkbit
 

--- a/internal/command.go
+++ b/internal/command.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/duration.go
+++ b/internal/duration.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/edge.go
+++ b/internal/edge.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/feature.go
+++ b/internal/feature.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/feature_download.go
+++ b/internal/feature_download.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/feature_install.go
+++ b/internal/feature_install.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/feature_internal.go
+++ b/internal/feature_internal.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/feature_test.go
+++ b/internal/feature_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/file_utils.go
+++ b/internal/file_utils.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/flags_test.go
+++ b/internal/flags_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package logger
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package logger
 

--- a/internal/status.go
+++ b/internal/status.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/status_test.go
+++ b/internal/status_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 

--- a/internal/storage/archive.go
+++ b/internal/storage/archive.go
@@ -9,6 +9,7 @@
 // which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
 package storage
 
 import (

--- a/internal/storage/archive.go
+++ b/internal/storage/archive.go
@@ -5,10 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
-
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 package storage
 
 import (

--- a/internal/storage/archive_test.go
+++ b/internal/storage/archive_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package storage
 

--- a/internal/storage/download.go
+++ b/internal/storage/download.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package storage
 

--- a/internal/storage/download_test.go
+++ b/internal/storage/download_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package storage
 

--- a/internal/storage/http_test_util.go
+++ b/internal/storage/http_test_util.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package storage
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package storage
 

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package storage
 

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package storage
 

--- a/internal/storage/utils_test.go
+++ b/internal/storage/utils_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package storage
 

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package feature
 


### PR DESCRIPTION
[#33] Apply the new Eclipse Kanto project license scheme

- headers updated

Signed-off-by: Georgi Boyvalenkov <Georgi.Boyvalenkov@bosch.io>