### PR TITLE
Progress status is added in first DOWNLOADING, INSTALLING and INSTALLED status event

### DIFF
--- a/hawkbit/README.md
+++ b/hawkbit/README.md
@@ -93,9 +93,10 @@ if err := su.SetContextDependencies(dependency); err != nil {
 ```go
 func installHandler(update *hawkbit.SoftwareUpdateAction, su *hawkbit.SoftwareUpdatable) {
     // Install provided software modules.
+	startProgress := 0
 	for _, module := range update.SoftwareModules {
 		status := hawkbit.NewOperationStatusUpdate(update.CorrelationID, hawkbit.StatusStarted, module.SoftwareModule).
-			WithProgress(0).WithMessage("install operation just started")
+			WithProgress(&startProgress).WithMessage("install operation just started")
 		if err := su.SetLastOperation(status); err != nil {
 			fmt.Println(fmt.Errorf("could not update the last operation: %v", err))
 		}

--- a/hawkbit/lib_operation_status.go
+++ b/hawkbit/lib_operation_status.go
@@ -24,7 +24,7 @@ type OperationStatus struct {
 	// Software is required for a remove or cancelRemove operation, absent in case of install/download/cancel.
 	Software []*DependencyDescription `json:"software,omitempty"`
 	// Progress represents the progress indicator in percentage.
-	Progress int `json:"progress,omitempty"`
+	Progress *int `json:"progress,omitempty"`
 	// Message from the device to give more context to the transmitted status.
 	Message string `json:"message,omitempty"`
 	// StatusCode represents a custom status code transmitted by the device.
@@ -67,7 +67,7 @@ func (os *OperationStatus) WithSoftware(software ...*DependencyDescription) *Ope
 }
 
 // WithProgress sets the progress of the operation status.
-func (os *OperationStatus) WithProgress(progress int) *OperationStatus {
+func (os *OperationStatus) WithProgress(progress *int) *OperationStatus {
 	os.Progress = progress
 	return os
 }

--- a/hawkbit/lib_operation_status_test.go
+++ b/hawkbit/lib_operation_status_test.go
@@ -55,7 +55,7 @@ func TestOperationStatusUpdate(t *testing.T) {
 	}
 
 	// 4. Test WithProgress value.
-	if ops.WithProgress(progress).Progress != progress {
+	if ops.WithProgress(&progress).Progress != progress {
 		t.Errorf("progress mishmash: %v != %v", ops.Progress, progress)
 	}
 

--- a/hawkbit/lib_operation_status_test.go
+++ b/hawkbit/lib_operation_status_test.go
@@ -55,7 +55,7 @@ func TestOperationStatusUpdate(t *testing.T) {
 	}
 
 	// 4. Test WithProgress value.
-	if ops.WithProgress(&progress).Progress != progress {
+	if *(ops.WithProgress(&progress).Progress) != progress {
 		t.Errorf("progress mishmash: %v != %v", ops.Progress, progress)
 	}
 

--- a/internal/feature_download.go
+++ b/internal/feature_download.go
@@ -34,6 +34,7 @@ func (f *ScriptBasedSoftwareUpdatable) downloadHandler(
 
 // downloadModule is called by download handler and after restart with remaining updatables.
 // returns true if canceled!
+// testing
 func (f *ScriptBasedSoftwareUpdatable) downloadModules(
 	toDir string, updatable *storage.Updatable, su *hawkbit.SoftwareUpdatable) bool {
 	// Process download operation.

--- a/internal/feature_download.go
+++ b/internal/feature_download.go
@@ -77,7 +77,7 @@ func (f *ScriptBasedSoftwareUpdatable) downloadModule(
 	var opError error
 	opErrorMsg := errRuntime
 	startProgress := 0
-	endProgress := 100
+	completeProgress := 100
 
 	// Process final operation status in defer to also catch potential panic calls.
 	defer func() {
@@ -136,7 +136,7 @@ Downloading:
 
 	// Downloaded
 	logger.Debugf("[%s.%s] Module download finished", module.Name, module.Version)
-	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloaded).WithProgress(&endProgress))
+	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloaded).WithProgress(&completeProgress))
 	storage.WriteLn(s, string(hawkbit.StatusDownloaded))
 	return false
 }

--- a/internal/feature_install.go
+++ b/internal/feature_install.go
@@ -73,7 +73,7 @@ func (f *ScriptBasedSoftwareUpdatable) installModule(
 	var opError error
 	opErrorMsg := errRuntime
 	startProgress := 0
-	endProgress := 100
+	completeProgress := 100
 	execInstallScriptDir := dir
 
 	// Process final operation status in defer to also catch potential panic calls.
@@ -144,7 +144,7 @@ Downloading:
 
 	// Downloaded
 	logger.Debugf("[%s.%s] Module download finished", module.Name, module.Version)
-	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloaded).WithProgress(&endProgress))
+	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloaded).WithProgress(&completeProgress))
 	storage.WriteLn(s, string(hawkbit.StatusDownloaded))
 Downloaded:
 
@@ -224,7 +224,7 @@ Installing:
 
 	// Installed
 	logger.Debugf("[%s.%s] Module installed", module.Name, module.Version)
-	setLastOS(su, newFileOS(execInstallScriptDir, cid, module, hawkbit.StatusInstalled).WithProgress(&endProgress))
+	setLastOS(su, newFileOS(execInstallScriptDir, cid, module, hawkbit.StatusInstalled).WithProgress(&completeProgress))
 
 	// Update installed dependencies
 	deps, err := f.store.LoadInstalledDeps()

--- a/internal/feature_install.go
+++ b/internal/feature_install.go
@@ -72,7 +72,8 @@ func (f *ScriptBasedSoftwareUpdatable) installModule(
 	s := filepath.Join(dir, storage.InternalStatusName)
 	var opError error
 	opErrorMsg := errRuntime
-
+	startProgress := 0
+	endProgress := 100
 	execInstallScriptDir := dir
 
 	// Process final operation status in defer to also catch potential panic calls.
@@ -128,11 +129,11 @@ func (f *ScriptBasedSoftwareUpdatable) installModule(
 Started:
 	// Downloading
 	logger.Debugf("[%s.%s] Downloading module", module.Name, module.Version)
-	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloading))
+	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloading).WithProgress(&startProgress))
 	storage.WriteLn(s, string(hawkbit.StatusDownloading))
 Downloading:
 	if opError = f.store.DownloadModule(dir, module, func(progress int) {
-		setLastOS(su, newOS(cid, module, hawkbit.StatusDownloading).WithProgress(progress))
+		setLastOS(su, newOS(cid, module, hawkbit.StatusDownloading).WithProgress(&progress))
 	}, f.serverCert, f.downloadRetryCount, f.downloadRetryInterval, func() error {
 		return f.validateLocalArtifacts(module)
 	}); opError != nil {
@@ -143,13 +144,13 @@ Downloading:
 
 	// Downloaded
 	logger.Debugf("[%s.%s] Module download finished", module.Name, module.Version)
-	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloaded).WithProgress(100))
+	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloaded).WithProgress(&endProgress))
 	storage.WriteLn(s, string(hawkbit.StatusDownloaded))
 Downloaded:
 
 	// Installing
 	logger.Debugf("[%s.%s] Installing module", module.Name, module.Version)
-	setLastOS(su, newOS(cid, module, hawkbit.StatusInstalling).WithProgress(0))
+	setLastOS(su, newOS(cid, module, hawkbit.StatusInstalling).WithProgress(&startProgress))
 	storage.WriteLn(s, string(hawkbit.StatusInstalling))
 Installing:
 
@@ -223,7 +224,7 @@ Installing:
 
 	// Installed
 	logger.Debugf("[%s.%s] Module installed", module.Name, module.Version)
-	setLastOS(su, newFileOS(execInstallScriptDir, cid, module, hawkbit.StatusInstalled))
+	setLastOS(su, newFileOS(execInstallScriptDir, cid, module, hawkbit.StatusInstalled).WithProgress(&endProgress))
 
 	// Update installed dependencies
 	deps, err := f.store.LoadInstalledDeps()

--- a/internal/feature_internal.go
+++ b/internal/feature_internal.go
@@ -191,7 +191,7 @@ func newFileOS(dir string, cid string, module *storage.Module, status hawkbit.St
 			if c != "" {
 				ops.WithStatusCode(c)
 			}
-			if p >= 0 && p <= 100 {
+			if p > 0 && p <= 100 {
 				ops.WithProgress(&p)
 			}
 			if m != "" {

--- a/internal/feature_internal.go
+++ b/internal/feature_internal.go
@@ -192,7 +192,7 @@ func newFileOS(dir string, cid string, module *storage.Module, status hawkbit.St
 				ops.WithStatusCode(c)
 			}
 			if p >= 0 && p <= 100 {
-				ops.WithProgress(p)
+				ops.WithProgress(&p)
 			}
 			if m != "" {
 				ops.WithMessage(m)

--- a/internal/feature_test.go
+++ b/internal/feature_test.go
@@ -181,10 +181,10 @@ func testDisconnectWhileRunningOperation(feature *ScriptBasedSoftwareUpdatable, 
 		feature.downloadHandler(sua, feature.su)
 	}
 	// only 1 artifact here
-	preDisconnectEventCount := 2  // STARTED, DOWNLOADING
-	postDisconnectEventCount := 3 // DOWNLOADING(100)/INSTALLING(100), DOWNLOADED/INSTALLED, FINISHED_SUCCESS
+	preDisconnectEventCount := 2  // STARTED, DOWNLOADING(0)
+	postDisconnectEventCount := 3 // DOWNLOADING(100)/INSTALLING(100), DOWNLOADED(100)/INSTALLED(100), FINISHED_SUCCESS
 	if install {
-		preDisconnectEventCount = 5 // STARTED, DOWNLOADING, DOWNLOADING(100), DOWNLOADED, INSTALLING
+		preDisconnectEventCount = 5 // STARTED, DOWNLOADING(0), DOWNLOADING(100), DOWNLOADED(100), INSTALLING(0)
 	}
 	statuses := pullStatusChanges(mc, preDisconnectEventCount) // should go between DOWNLOADING/INSTALLING and next state
 
@@ -334,7 +334,7 @@ func testDownloadInstall(feature *ScriptBasedSoftwareUpdatable, mc *mockedClient
 	// Try to execute a simple download operation.
 	feature.downloadHandler(sua, feature.su)
 
-	statuses := pullStatusChanges(mc, 5+extraDownloadingEventsCount) // STARTED, DOWNLOADING(0), DOWNLOADING(x extraDownloadingEventsCount), DOWNLOADING(100), DOWNLOADED, FINISHED_SUCCESS
+	statuses := pullStatusChanges(mc, 5+extraDownloadingEventsCount) // STARTED, DOWNLOADING(0), DOWNLOADING(x extraDownloadingEventsCount), DOWNLOADING(100), DOWNLOADED(100), FINISHED_SUCCESS
 	if expectedSuccess {
 		checkDownloadStatusEvents(extraDownloadingEventsCount, statuses, t)
 		if copyArtifacts == "" {

--- a/internal/feature_test.go
+++ b/internal/feature_test.go
@@ -334,7 +334,7 @@ func testDownloadInstall(feature *ScriptBasedSoftwareUpdatable, mc *mockedClient
 	// Try to execute a simple download operation.
 	feature.downloadHandler(sua, feature.su)
 
-	statuses := pullStatusChanges(mc, 5+extraDownloadingEventsCount) // STARTED, DOWNLOADING, DOWNLOADING(x extraDownloadingEventsCount), DOWNLOADING(100), DOWNLOADED, FINISHED_SUCCESS
+	statuses := pullStatusChanges(mc, 5+extraDownloadingEventsCount) // STARTED, DOWNLOADING(0), DOWNLOADING(x extraDownloadingEventsCount), DOWNLOADING(100), DOWNLOADED, FINISHED_SUCCESS
 	if expectedSuccess {
 		checkDownloadStatusEvents(extraDownloadingEventsCount, statuses, t)
 		if copyArtifacts == "" {
@@ -349,8 +349,8 @@ func testDownloadInstall(feature *ScriptBasedSoftwareUpdatable, mc *mockedClient
 	// Try to execute a simple install operation.
 	feature.installHandler(sua, feature.su)
 
-	statuses = pullStatusChanges(mc, 8+extraDownloadingEventsCount) // STARTED, DOWNLOADING, DOWNLOADING(x extraDownloadingEventsCount), DOWNLOADING(100), DOWNLOADED,
-	// INSTALLING, INSTALLING(100), INSTALLED, FINISHED_SUCCESS
+	statuses = pullStatusChanges(mc, 8+extraDownloadingEventsCount) // STARTED, DOWNLOADING(0), DOWNLOADING(x extraDownloadingEventsCount), DOWNLOADING(100), DOWNLOADED(100),
+	// INSTALLING(0), INSTALLING(100), INSTALLED(100), FINISHED_SUCCESS
 	if expectedSuccess {
 		checkInstallStatusEvents(extraDownloadingEventsCount, statuses, t)
 	} else {
@@ -372,7 +372,7 @@ func checkDownloadFailedStatusEvents(actualStatuses []interface{}, t *testing.T)
 	var expectedStatuses []interface{}
 	expectedStatuses = append(expectedStatuses,
 		createStatus(hawkbit.StatusStarted, nil, noMessage),
-		createStatus(hawkbit.StatusDownloading, nil, noMessage),
+		createStatus(hawkbit.StatusDownloading, partialProgress, noMessage),
 		createStatus(hawkbit.StatusFinishedError, nil, anyErrorMessage),
 	)
 	checkStatusEvents(expectedStatuses, actualStatuses, t)
@@ -382,14 +382,14 @@ func checkDownloadStatusEvents(extraDownloadingEventsCount int, actualStatuses [
 	var expectedStatuses []interface{}
 	expectedStatuses = append(expectedStatuses,
 		createStatus(hawkbit.StatusStarted, nil, noMessage),
-		createStatus(hawkbit.StatusDownloading, nil, noMessage),
+		createStatus(hawkbit.StatusDownloading, partialProgress, noMessage),
 	)
 	for i := 0; i < extraDownloadingEventsCount; i++ {
-		expectedStatuses = append(expectedStatuses, createStatus(hawkbit.StatusDownloading, partialDownload, noMessage))
+		expectedStatuses = append(expectedStatuses, createStatus(hawkbit.StatusDownloading, partialProgress, noMessage))
 	}
 	expectedStatuses = append(expectedStatuses,
-		createStatus(hawkbit.StatusDownloading, completeDownload, noMessage),
-		createStatus(hawkbit.StatusDownloaded, completeDownload, noMessage),
+		createStatus(hawkbit.StatusDownloading, completeProgress, noMessage),
+		createStatus(hawkbit.StatusDownloaded, completeProgress, noMessage),
 		createStatus(hawkbit.StatusFinishedSuccess, nil, noMessage),
 	)
 	checkStatusEvents(expectedStatuses, actualStatuses, t)
@@ -399,17 +399,17 @@ func checkInstallStatusEvents(extraDownloadingEventsCount int, actualStatuses []
 	var expectedStatuses []interface{}
 	expectedStatuses = append(expectedStatuses,
 		createStatus(hawkbit.StatusStarted, nil, noMessage),
-		createStatus(hawkbit.StatusDownloading, nil, noMessage),
+		createStatus(hawkbit.StatusDownloading, partialProgress, noMessage),
 	)
 	for i := 0; i < extraDownloadingEventsCount; i++ {
-		expectedStatuses = append(expectedStatuses, createStatus(hawkbit.StatusDownloading, partialDownload, noMessage))
+		expectedStatuses = append(expectedStatuses, createStatus(hawkbit.StatusDownloading, partialProgress, noMessage))
 	}
 	expectedStatuses = append(expectedStatuses,
-		createStatus(hawkbit.StatusDownloading, completeDownload, noMessage),
-		createStatus(hawkbit.StatusDownloaded, completeDownload, noMessage),
-		createStatus(hawkbit.StatusInstalling, nil, noMessage),
-		createStatus(hawkbit.StatusInstalling, nil, "My final message!"),
-		createStatus(hawkbit.StatusInstalled, nil, "My final message!"),
+		createStatus(hawkbit.StatusDownloading, completeProgress, noMessage),
+		createStatus(hawkbit.StatusDownloaded, completeProgress, noMessage),
+		createStatus(hawkbit.StatusInstalling, partialProgress, noMessage),
+		createStatus(hawkbit.StatusInstalling, partialProgress, "My final message!"),
+		createStatus(hawkbit.StatusInstalled, completeProgress, "My final message!"),
 		createStatus(hawkbit.StatusFinishedSuccess, nil, "My final message!"),
 	)
 	checkStatusEvents(expectedStatuses, actualStatuses, t)

--- a/internal/status.go
+++ b/internal/status.go
@@ -45,7 +45,7 @@ func (o *monitor) update(name string) {
 		o.oldMessage = m
 		o.oldStatusCode = c
 		ops := hawkbit.NewOperationStatusUpdate(o.cid, o.status, o.module).
-			WithProgress(p).WithMessage(m).WithStatusCode(c)
+			WithProgress(&p).WithMessage(m).WithStatusCode(c)
 		if err := o.su.SetLastOperation(ops); err != nil {
 			logger.Errorf("fail to send last operation status: %v", err)
 		}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -73,10 +73,10 @@ type testConfig struct {
 var (
 	testVersion = "TestVersion"
 
-	partialDownload = func(progress float64) bool {
-		return progress > 0 && progress < 100
+	partialProgress = func(progress float64) bool {
+		return progress >= 0 && progress < 100
 	}
-	completeDownload = func(progress float64) bool {
+	completeProgress = func(progress float64) bool {
 		return progress == 100
 	}
 )


### PR DESCRIPTION
[#31] Consider setting progress when operation status is changed to DOWNLOADING or INSTALLING/INSTALLED 

Updated event status sequence:

1. **When downloading** an artifact is STARTED, DOWNLOADING(with progress set at 0%), DOWNLOADING(with progress set at 0 to 100%), DOWNLOADED(with progress set at 100%), FINISHED_SUCCESS.

1. **When installing** an artifact, additional events are generated: INSTALLING(with progress set at 0%), INSTALLED(with progress set at 100%), FINISHED_SUCCESS.


**Local MQTT Logs**: [software_update_mqtt.log](https://github.com/user-attachments/files/17517687/software_update_mqtt.log)
