### PR TITLE
[#31] Consider setting progress when operation status is changed to DOWNLOADING or INSTALLING/INSTALLED

### DIFF
--- a/hawkbit/README.md
+++ b/hawkbit/README.md
@@ -93,9 +93,10 @@ if err := su.SetContextDependencies(dependency); err != nil {
 ```go
 func installHandler(update *hawkbit.SoftwareUpdateAction, su *hawkbit.SoftwareUpdatable) {
     // Install provided software modules.
+	startProgress := 0
 	for _, module := range update.SoftwareModules {
 		status := hawkbit.NewOperationStatusUpdate(update.CorrelationID, hawkbit.StatusStarted, module.SoftwareModule).
-			WithProgress(0).WithMessage("install operation just started")
+			WithProgress(&startProgress).WithMessage("install operation just started")
 		if err := su.SetLastOperation(status); err != nil {
 			fmt.Println(fmt.Errorf("could not update the last operation: %v", err))
 		}

--- a/hawkbit/lib_dependency_description.go
+++ b/hawkbit/lib_dependency_description.go
@@ -12,6 +12,14 @@
 
 package hawkbit
 
+// DependencyDescription structure keys
+const (
+	softwareGroupParam   = "group"
+	softwareNameParam    = "name"
+	softwareVersionParam = "version"
+	softwareTypeParam    = "type"
+)
+
 // DependencyDescription describes an installed software or other dependencies for a device.
 type DependencyDescription struct {
 	// Group represents an identifier which groups the dependency into a certain category.

--- a/hawkbit/lib_dependency_description.go
+++ b/hawkbit/lib_dependency_description.go
@@ -12,7 +12,7 @@
 
 package hawkbit
 
-// DependencyDescription structure keys
+// Software DependencyDescription structure keys
 const (
 	softwareGroupParam   = "group"
 	softwareNameParam    = "name"

--- a/hawkbit/lib_operation_status.go
+++ b/hawkbit/lib_operation_status.go
@@ -24,7 +24,7 @@ type OperationStatus struct {
 	// Software is required for a remove or cancelRemove operation, absent in case of install/download/cancel.
 	Software []*DependencyDescription `json:"software,omitempty"`
 	// Progress represents the progress indicator in percentage.
-	Progress int `json:"progress,omitempty"`
+	Progress *int `json:"progress,omitempty"`
 	// Message from the device to give more context to the transmitted status.
 	Message string `json:"message,omitempty"`
 	// StatusCode represents a custom status code transmitted by the device.
@@ -67,7 +67,7 @@ func (os *OperationStatus) WithSoftware(software ...*DependencyDescription) *Ope
 }
 
 // WithProgress sets the progress of the operation status.
-func (os *OperationStatus) WithProgress(progress int) *OperationStatus {
+func (os *OperationStatus) WithProgress(progress *int) *OperationStatus {
 	os.Progress = progress
 	return os
 }

--- a/hawkbit/lib_operation_status.go
+++ b/hawkbit/lib_operation_status.go
@@ -12,6 +12,17 @@
 
 package hawkbit
 
+// OperationStatus structure keys
+const (
+	correlationIdParam  = "correlationId"
+	statusParam         = "status"
+	softwareModuleParam = "softwareModule"
+	SoftwareParam       = "Software"
+	progressParam       = "progress"
+	messageParam        = "message"
+	statusCodeParam     = "statusCode"
+)
+
 // OperationStatus represents the status of an operation (install/remove) called on a device.
 type OperationStatus struct {
 	// CorrelationID is used for correlating the status-update with the operation called before.

--- a/hawkbit/lib_operation_status.go
+++ b/hawkbit/lib_operation_status.go
@@ -14,7 +14,7 @@ package hawkbit
 
 // OperationStatus structure keys
 const (
-	correlationIdParam  = "correlationId"
+	correlationIDParam  = "correlationID"
 	statusParam         = "status"
 	softwareModuleParam = "softwareModule"
 	SoftwareParam       = "Software"

--- a/hawkbit/lib_operation_status_test.go
+++ b/hawkbit/lib_operation_status_test.go
@@ -55,7 +55,7 @@ func TestOperationStatusUpdate(t *testing.T) {
 	}
 
 	// 4. Test WithProgress value.
-	if ops.WithProgress(progress).Progress != progress {
+	if *(ops.WithProgress(&progress).Progress) != progress {
 		t.Errorf("progress mishmash: %v != %v", ops.Progress, progress)
 	}
 

--- a/hawkbit/lib_software_module_id.go
+++ b/hawkbit/lib_software_module_id.go
@@ -12,6 +12,12 @@
 
 package hawkbit
 
+// SoftwareModuleID structure keys
+const (
+	softwareModuleNameParam    = "name"
+	softwareModuleVersionParam = "version"
+)
+
 // SoftwareModuleID represents an unique identifier for software modules.
 type SoftwareModuleID struct {
 	// Name for the software module.

--- a/hawkbit/software_updatable.go
+++ b/hawkbit/software_updatable.go
@@ -136,7 +136,7 @@ func (su *SoftwareUpdatable) SetContextDependencies(deps ...*DependencyDescripti
 // This enables the logging of last operation status with keys and values
 func MapLastOperation(LastOperationPtr *OperationStatus) map[string]interface{} {
 	lastOperationMap := make(map[string]interface{})
-	lastOperationMap[correlationIdParam] = LastOperationPtr.CorrelationID
+	lastOperationMap[correlationIDParam] = LastOperationPtr.CorrelationID
 	lastOperationMap[statusParam] = LastOperationPtr.Status
 
 	if LastOperationPtr.SoftwareModule != nil {

--- a/hawkbit/software_updatable.go
+++ b/hawkbit/software_updatable.go
@@ -169,7 +169,7 @@ func MapLastOperation(LastOperationPtr *OperationStatus) map[string]interface{} 
 	}
 
 	if LastOperationPtr.StatusCode != "" {
-		lastOperationMap[progressParam] = LastOperationPtr.StatusCode
+		lastOperationMap[statusCodeParam] = LastOperationPtr.StatusCode
 	}
 
 	return lastOperationMap

--- a/hawkbit/software_updatable.go
+++ b/hawkbit/software_updatable.go
@@ -132,6 +132,49 @@ func (su *SoftwareUpdatable) SetContextDependencies(deps ...*DependencyDescripti
 	return su.setProperty(suPropertyContextDependencies, su.status.ContextDependencies)
 }
 
+// MapLastOperation converts the OperationStatus into map interface
+// This enables the logging of last operation status with keys and values
+func MapLastOperation(LastOperationPtr *OperationStatus) map[string]interface{} {
+	lastOperationMap := make(map[string]interface{})
+	lastOperationMap[correlationIdParam] = LastOperationPtr.CorrelationID
+	lastOperationMap[statusParam] = LastOperationPtr.Status
+
+	if LastOperationPtr.SoftwareModule != nil {
+		lastOperationMap[softwareModuleParam] = map[string]interface{}{
+			softwareModuleNameParam:    LastOperationPtr.SoftwareModule.Name,
+			softwareModuleVersionParam: LastOperationPtr.SoftwareModule.Version,
+		}
+	}
+
+	if LastOperationPtr.Software != nil {
+		var softwareDependencies []map[string]interface{}
+		for _, values := range LastOperationPtr.Software {
+			dependency := map[string]interface{}{
+				softwareGroupParam:   values.Group,
+				softwareNameParam:    values.Name,
+				softwareVersionParam: values.Version,
+				softwareTypeParam:    values.Type,
+			}
+			softwareDependencies = append(softwareDependencies, dependency)
+		}
+		lastOperationMap[SoftwareParam] = softwareDependencies
+	}
+
+	if LastOperationPtr.Progress != nil {
+		lastOperationMap[progressParam] = *LastOperationPtr.Progress
+	}
+
+	if LastOperationPtr.Message != "" {
+		lastOperationMap[messageParam] = LastOperationPtr.Message
+	}
+
+	if LastOperationPtr.StatusCode != "" {
+		lastOperationMap[progressParam] = LastOperationPtr.StatusCode
+	}
+
+	return lastOperationMap
+}
+
 // SetLastOperation set the last operation and last failed operation (if needed) of
 // underlying SoftwareUpdatable feature.
 // Note: Involking this function before the feature activation will change
@@ -146,9 +189,9 @@ func (su *SoftwareUpdatable) SetLastOperation(os *OperationStatus) error {
 	if os != nil && (os.Status == StatusFinishedError || os.Status == StatusFinishedRejected ||
 		os.Status == StatusCancelRejected) {
 		su.status.LastFailedOperation = su.status.LastOperation
-		if err := su.setProperty(suPropertyLastFailedOperation, su.status.LastFailedOperation); err != nil {
+		if err := su.setProperty(suPropertyLastFailedOperation, MapLastOperation(su.status.LastFailedOperation)); err != nil {
 			return err
 		}
 	}
-	return su.setProperty(suPropertyLastOperation, su.status.LastOperation)
+	return su.setProperty(suPropertyLastOperation, MapLastOperation(su.status.LastOperation))
 }

--- a/internal/feature_download.go
+++ b/internal/feature_download.go
@@ -76,6 +76,8 @@ func (f *ScriptBasedSoftwareUpdatable) downloadModule(
 	s := filepath.Join(toDir, storage.InternalStatusName)
 	var opError error
 	opErrorMsg := errRuntime
+	startProgress := 0
+	completeProgress := 100
 
 	// Process final operation status in defer to also catch potential panic calls.
 	defer func() {
@@ -119,11 +121,11 @@ Started:
 
 	// Downloading
 	logger.Debugf("[%s.%s] Downloading module", module.Name, module.Version)
-	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloading))
+	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloading).WithProgress(&startProgress))
 	storage.WriteLn(s, string(hawkbit.StatusDownloading))
 Downloading:
-	if opError = f.store.DownloadModule(toDir, module, func(percent int) {
-		setLastOS(su, newOS(cid, module, hawkbit.StatusDownloading).WithProgress(percent))
+	if opError = f.store.DownloadModule(toDir, module, func(progress int) {
+		setLastOS(su, newOS(cid, module, hawkbit.StatusDownloading).WithProgress(&progress))
 	}, f.serverCert, f.downloadRetryCount, f.downloadRetryInterval, func() error {
 		return f.validateLocalArtifacts(module)
 	}); opError != nil {
@@ -134,7 +136,7 @@ Downloading:
 
 	// Downloaded
 	logger.Debugf("[%s.%s] Module download finished", module.Name, module.Version)
-	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloaded).WithProgress(100))
+	setLastOS(su, newOS(cid, module, hawkbit.StatusDownloaded).WithProgress(&completeProgress))
 	storage.WriteLn(s, string(hawkbit.StatusDownloaded))
 	return false
 }

--- a/internal/feature_internal.go
+++ b/internal/feature_internal.go
@@ -191,8 +191,8 @@ func newFileOS(dir string, cid string, module *storage.Module, status hawkbit.St
 			if c != "" {
 				ops.WithStatusCode(c)
 			}
-			if p >= 0 && p <= 100 {
-				ops.WithProgress(p)
+			if p > 0 && p <= 100 {
+				ops.WithProgress(&p)
 			}
 			if m != "" {
 				ops.WithMessage(m)

--- a/internal/status.go
+++ b/internal/status.go
@@ -45,7 +45,7 @@ func (o *monitor) update(name string) {
 		o.oldMessage = m
 		o.oldStatusCode = c
 		ops := hawkbit.NewOperationStatusUpdate(o.cid, o.status, o.module).
-			WithProgress(p).WithMessage(m).WithStatusCode(c)
+			WithProgress(&p).WithMessage(m).WithStatusCode(c)
 		if err := o.su.SetLastOperation(ops); err != nil {
 			logger.Errorf("fail to send last operation status: %v", err)
 		}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -73,10 +73,10 @@ type testConfig struct {
 var (
 	testVersion = "TestVersion"
 
-	partialDownload = func(progress float64) bool {
-		return progress > 0 && progress < 100
+	partialProgress = func(progress float64) bool {
+		return progress >= 0 && progress < 100
 	}
-	completeDownload = func(progress float64) bool {
+	completeProgress = func(progress float64) bool {
 		return progress == 100
 	}
 )


### PR DESCRIPTION
Updated event status sequence:

1. **When downloading** an artifact is STARTED, DOWNLOADING(with progress set at 0%), DOWNLOADING(with progress set at 0 to 100%), DOWNLOADED(with progress set at 100%), FINISHED_SUCCESS.

2. **When installing** an artifact, additional events are generated: INSTALLING(with progress set at 0%), INSTALLED(with progress set at 100%), FINISHED_SUCCESS.

Logs: 
[loca_mqtt_logs.txt](https://github.com/user-attachments/files/17531512/loca_mqtt_logs.txt)
[software-update.log](https://github.com/user-attachments/files/17531520/software-update.log)
